### PR TITLE
Feature/pre set time

### DIFF
--- a/osmcal/views.py
+++ b/osmcal/views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from datetime import timedelta
 from xml.etree import ElementTree as ET
 
@@ -310,7 +311,20 @@ class DuplicateEvent(EditEvent):
     @method_decorator(login_required)
     def get(self, request, event_id):
         old_evt = Event.objects.get(id=event_id)
-        form = forms.EventForm(initial=self.dict_from_event(old_evt, ('name', 'whole_day', 'link', 'kind', 'location_name', 'location', 'description')))
+        new_datetime = datetime.now().replace(
+            hour=old_evt.start.hour,
+            minute=old_evt.start.minute,
+        )
+        form = forms.EventForm(initial={
+            'name': old_evt.name,
+            'start': new_datetime,
+            'whole_day': old_evt.whole_day,
+            'link': old_evt.link,
+            'kind': old_evt.kind,
+            'location_name': old_evt.location_name,
+            'location': old_evt.location,
+            'description': old_evt.description,
+        })
         form.cleaned_data = {}
         form.add_error('start', 'please set')
         if old_evt.end:


### PR DESCRIPTION
Fix issue with duplicating the *start* time -- it make sense to copy the start date/time, becuase the date will be changed anyway but the time don't have to be. (So there is few clicks less when start date/time copied compared to not copied.)