### PR TITLE
Fix grammar

### DIFF
--- a/osmcal/templates/osmcal/documentation.html
+++ b/osmcal/templates/osmcal/documentation.html
@@ -44,7 +44,7 @@
 
 <h3>Why is there no support for repeated/periodic events?</h3>
 
-<p>Because we don't want to list events that potentially do not exist anymore because their initial creators forgot to remove them. Our alternative is the 'Repeat Event' functionality which you can reach from the event's detail page which allows you to copy an existing event.</p>
+<p>Because we don't want to list events that potentially do not exist anymore because their initial creators forgot to remove them. Our alternative is the 'Repeat Event' functionality which you can reach from the event's detail page and allows you to copy an existing event.</p>
 
 </content>
 {% endblock %}


### PR DESCRIPTION
Use summation "and" (refers to "the 'Repeat Event' functionality") instead of incorrect, duplicate "which" (refers to "the event's detail page").