### PR TITLE
Change content class to fullwidth for event_join.html

### DIFF
--- a/osmcal/templates/osmcal/event_join.html
+++ b/osmcal/templates/osmcal/event_join.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
+<div class="content-main-fullwidth">
+
 	<h1 class="event-single-title">Join <a href="{% url 'event' event.id %}">{{ event.name }}</a></h1>
 	On {% include "osmcal/date.txt" %}
 
@@ -8,4 +10,5 @@
 		{% csrf_token %}
 		<button class="btn">Attend {{ event.name }}</button>
 	</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
Part of #98. Set a margin, similar to [event_participants.html](https://github.com/thomersch/openstreetmap-calendar/blob/master/osmcal/templates/osmcal/event_participants.html), by using `content-main-fullwidth` instead of default `content-main`.

![image](https://github.com/thomersch/openstreetmap-calendar/assets/67521919/ade73bb9-b98a-4545-8cb1-8abe90bc5c24)
