### PR TITLE
Update event_survey.html - Correct grammar

### DIFF
--- a/osmcal/templates/osmcal/event_survey.html
+++ b/osmcal/templates/osmcal/event_survey.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 	<h1>Attend ”{{ event.name }}”</h1>
-	<div class="text">The event organiser wants you to answer you some questions for sign-up. Answers are publicly visible.</div>
+	<div class="text">The event organiser wants you to answer some questions for sign-up. Answers are publicly visible.</div>
 
 	<form method="POST">
 		<input hidden name="signup-answers" value="1">


### PR DESCRIPTION
Remove duplicate word "you"

(sidenote: it is only relevant to answer "for sign-up", not when/who/how you answer, so adding i.e. (possessive) pronoun "them"/"(them) their questions" is redundant.)