### PR TITLE
event/form: set pointer cursor on timezone link

### DIFF
--- a/osmcal/static/osmcal/event-form.css
+++ b/osmcal/static/osmcal/event-form.css
@@ -36,6 +36,10 @@
 	color: #666666;
 }
 
+timezone-widget a {
+	cursor: pointer;
+}
+
 .event-form textarea {
 	font-size: 12pt;
 	width: 100%;


### PR DESCRIPTION
## Summary
- Add a pointer cursor to the timezone widget manual-set link.

## Context
Fixes #156.

## Testing
- git diff --check
- uv run ./manage.py check (fails locally because GDAL/devbox is unavailable in this environment, before reaching this CSS-only change)